### PR TITLE
Expanded network health indicator uses+limitations

### DIFF
--- a/patterns/cautious-optimism.md
+++ b/patterns/cautious-optimism.md
@@ -71,3 +71,5 @@ bad behavior.
 ## References & Where to Learn More
 
 The "tit for tat" strategy
+
+See [network health indicators](patterns/network-health-indicator.md) for one implementation strategy, tracking how long peers host data to determine whether to share with them in the future

--- a/patterns/conditional-file-sharing.md
+++ b/patterns/conditional-file-sharing.md
@@ -54,3 +54,5 @@ When there is a large amount of information on the network with varied relevance
 Conditional sharing helps users collectively keep data online when it needs to be without a central coordinator.
 
 ## References and Where to Learn More
+
+Integrating the data availability layer (p2p redundant hosting) with tracking where data is being shared can provide insight into how data is being used by peers. See [network health indicators](patterns/network-health-indicator.md) for more.

--- a/patterns/network-health-indicator.md
+++ b/patterns/network-health-indicator.md
@@ -93,6 +93,6 @@ Network health indicators reassure users and build trust in the stability and re
 
 Network health indicators overlap with reputation and trust management, in that hosting data for a long period of time can be used to gauge the reliability of a peer. See [cautious optimism](patterns/cautious-optimism.md) and [conditional file sharing](patterns/conditional-file-sharing.md). There are potential applications related to preventing DDoS and Sybil attacks.
 
-Using heartbeats to confirm _lack of data availability_ is one component of [tombstones](patterns/tombstones.md).
+Network [heartbeats](https://en.wikipedia.org/wiki/Heartbeat_(computing)) confirm _lack of data availability_, a component of [tombstones](patterns/tombstones.md).
 
 Tracking peers that re-host content can be used for social peer discovery, because someone mirroring files on an obscure topic likely shares that obscure interest.

--- a/patterns/network-health-indicator.md
+++ b/patterns/network-health-indicator.md
@@ -48,8 +48,10 @@ data is safely replicated to another device and they can turn off their computer
 
 ## Why Choose Network Heath Indicator?
 
-When users are trusting your application with storing data that is important to
-them.
+- Confirm that shared data remains widely available
+- Confirm that hosts supply data for a long time
+- Confirm that hosts do _not_ continue providing files after a deletion request
+- Identify peers with similar interests
 
 ## Best Practice: How to Implement Network Health Indicator
 
@@ -75,8 +77,22 @@ them.
   of a dataset has been replicated by particular devices. This is required
   to make Network Health Indicator more informative and accurate.
 
+- Network Health Indicators may be unreliable in offline-first or sneakernet networks,
+  where peers are online and synchronizing data infrequently, and disconnect from the
+  network for large stretches of time. Implementing indicators in these environments
+  may require tracking detailed network health history rather than continued uptime.
+  Alternatively, utilize a notification protocol, such that peers notify one another
+  when they are connected and available, rather than nodes polling all peers
+  periodically to discover availability.
+
 ## The Take-Away
 
 Network health indicators reassure users and build trust in the stability and resilience of their data.
 
 ## References & Where to Learn More
+
+Network health indicators overlap with reputation and trust management, in that hosting data for a long period of time can be used to gauge the reliability of a peer. See [cautious optimism](patterns/cautious-optimism.md) and [conditional file sharing](patterns/conditional-file-sharing.md). There are potential applications related to preventing DDoS and Sybil attacks.
+
+Using heartbeats to confirm _lack of data availability_ is one component of [tombstones](patterns/tombstones.md).
+
+Tracking peers that re-host content can be used for social peer discovery, because someone mirroring files on an obscure topic likely shares that obscure interest.

--- a/patterns/tombstones.md
+++ b/patterns/tombstones.md
@@ -40,4 +40,4 @@ We can encourage deletion across the network quite well by using Tombstones.
 
 ## References & Where to Learn More
 
-"Network heartbeats" can track which peers with a copy of data continue to share it after a tombstone has been sent. See [network health indicators](patterns/network-health-indicator.md) for more on this approach.
+Network "[heartbeats](https://en.wikipedia.org/wiki/Heartbeat_(computing))" can track which peers with a copy of data continue to share it after a tombstone has been sent. See [network health indicators](patterns/network-health-indicator.md) for more on this approach.

--- a/patterns/tombstones.md
+++ b/patterns/tombstones.md
@@ -39,3 +39,5 @@ We can encourage deletion across the network quite well by using Tombstones.
 - Depending on the protocol or library you choose for storage, it may not be possible to delete historical data. In this case, tombstones only 'hide' data from view, rather than delete it from disk.
 
 ## References & Where to Learn More
+
+"Network heartbeats" can track which peers with a copy of data continue to share it after a tombstone has been sent. See [network health indicators](patterns/network-health-indicator.md) for more on this approach.


### PR DESCRIPTION
This pull is based on the conversation in issue #25, and I believe closes that issue. Network health indicators should be revised again once a pattern is added for social peer discovery, which `network-health-indicators.md` currently alludes to but can't directly reference. Edits welcome.