### PR TITLE
fix: Add description and category tags

### DIFF
--- a/patterns/QR-code-verification.md
+++ b/patterns/QR-code-verification.md
@@ -2,7 +2,7 @@
 title: QR Code Verification
 tags:
   - pattern
-  - ui 
+  - ui
 category: sharing-permissions
 description: "Securely verify or transfer information between two peers."
 layout: pattern
@@ -10,9 +10,9 @@ layout: pattern
 
 ## The Design Problem
 
-Use QR codes to quickly scan and verify that a device or some information is secure. In a typical centralized application, we trust the person or company operating the website to verify content. A particular profile or piece of content is mediated by this central server. 
+Use QR codes to quickly scan and verify that a device or some information is secure. In a typical centralized application, we trust the person or company operating the website to verify content. A particular profile or piece of content is mediated by this central server.
 
-However, decentralized applications often rely upon very long strings of characters and/or numbers to identify people or a piece of information, especially for secure communication or secret groups. These very long URLS can be difficult to share in some cases. 
+However, decentralized applications often rely upon very long strings of characters and/or numbers to identify people or a piece of information, especially for secure communication or secret groups. These very long URLS can be difficult to share in some cases.
 
 ## The Design Solution
 

--- a/patterns/QR-code-verification.md
+++ b/patterns/QR-code-verification.md
@@ -2,8 +2,9 @@
 title: QR Code Verification
 tags:
   - pattern
-  - app
-  - sharing
+  - ui 
+category: sharing-permissions
+description: "Securely verify or transfer information between two peers."
 layout: pattern
 ---
 

--- a/patterns/address.md
+++ b/patterns/address.md
@@ -3,7 +3,7 @@ title: Address
 category: identity-agency
 tags:
   - pattern
-  - ui 
+  - ui
   - protocol
 layout: pattern
 description: "Users are uniquely identified by their handle and a server name."
@@ -61,4 +61,3 @@ Identity](persistent-identity.md) for making portability more secure.
 Address can help give users trust in who they're talking to.
 
 ## References & Where to Learn More
-

--- a/patterns/address.md
+++ b/patterns/address.md
@@ -1,10 +1,12 @@
 ---
 title: Address
+category: identity-agency
 tags:
   - pattern
-  - identity
-  - federation
+  - ui 
+  - protocol
 layout: pattern
+description: "Users are uniquely identified by their handle and a server name."
 ---
 
 ## The Design Problem

--- a/patterns/age-indicator.md
+++ b/patterns/age-indicator.md
@@ -3,7 +3,7 @@ title: Age Indicator
 category: sync-status
 tags:
   - pattern
-  - ui 
+  - ui
 layout: pattern
 description: "Quickly distinguish if information is viral or stale"
 ---
@@ -32,7 +32,7 @@ Age indicator shows you information about participants without taking up too muc
 
 - Age Indicator is most effective when it comes to time sensitive information,
   like a 'best-before-date' feature. It highlights when something needs to be
-  checked for validity. As such, it enables an assertion of truth as 
+  checked for validity. As such, it enables an assertion of truth as
   information gets referenced over time.
 - Make sure context is always clear.
 - Use Age Indicator in combination with a [network health

--- a/patterns/age-indicator.md
+++ b/patterns/age-indicator.md
@@ -1,9 +1,11 @@
 ---
 title: Age Indicator
+category: sync-status
 tags:
   - pattern
-  - sync
+  - ui 
 layout: pattern
+description: "Quickly distinguish if information is viral or stale"
 ---
 
 ## The Design Problem
@@ -24,8 +26,7 @@ Trello’s Card Aging
 
 ## Why Choose Age Indicator?
 
-- Age indicator shows you information about participants without taking up too much space.
-- It comes in handy to distinguish if information is viral or stale.
+Age indicator shows you information about participants without taking up too much space. It comes in handy to distinguish if information is viral or stale.
 
 ## Best Practice: How to Implement Age Indicator
 
@@ -51,7 +52,7 @@ Trello’s Card Aging
 
 ## The Take-Away
 
-Age indicator is very important when the age of content affects how a user
+Age indicator helps guide users when the age of content affects how a user
 should interact with it.
 
 ## References and Where To Learn More

--- a/patterns/cautious-optimism.md
+++ b/patterns/cautious-optimism.md
@@ -1,10 +1,11 @@
 ---
 title: Cautious Optimism
+category: moderation-curation
 tags:
   - pattern
-  - curation
   - protocol
 layout: pattern
+descrpition: "Build opportunities for detecting and reacting to bad behavior"
 ---
 
 ## The Design Problem

--- a/patterns/conditional-file-sharing.md
+++ b/patterns/conditional-file-sharing.md
@@ -1,10 +1,11 @@
 ---
 title: Conditional File Sharing
+category: moderation-curation
 tags:
   - pattern
-  - resilience
-  - app
+  - ui 
 layout: pattern
+description: "Help users collectively keep data online"
 ---
 
 ## The Design Problem

--- a/patterns/conditional-file-sharing.md
+++ b/patterns/conditional-file-sharing.md
@@ -3,7 +3,7 @@ title: Conditional File Sharing
 category: moderation-curation
 tags:
   - pattern
-  - ui 
+  - ui
 layout: pattern
 description: "Help users collectively keep data online"
 ---

--- a/patterns/content-curators.md
+++ b/patterns/content-curators.md
@@ -1,10 +1,11 @@
 ---
 title: Content Curators
+category: moderation-curation
 tags:
   - pattern
-  - curation
-  - activity
+  - ui
 layout: pattern
+description: "Choice, flexibility, and control over feeds."
 ---
 
 ## The Design Problem

--- a/patterns/discovery-pub.md
+++ b/patterns/discovery-pub.md
@@ -1,6 +1,6 @@
 ---
 title: Discovery Pub
-category:  sync-status
+category: sync-status
 tags:
   - pattern
   - protocol
@@ -23,7 +23,7 @@ In a peer-to-peer application, you can only search for what you have downloaded,
 
 ## The Design Solution
 
-Users need to obtain a basic understanding of the differences between search that is mediated by federation and search enabled by a central service. Pair with the [Content Curators](content-curators.md) pattern. 
+Users need to obtain a basic understanding of the differences between search that is mediated by federation and search enabled by a central service. Pair with the [Content Curators](content-curators.md) pattern.
 
 Allow users to opt-in to search and discovery of content. For search, add indicators for scope (e.g., local vs global). For discovery, add indicators for filtering and curation. Allow users to opt-out of having their content searched through (e.g. locally vs globally).
 
@@ -44,7 +44,7 @@ When your application is heavily enriched by the ability to search and discover 
 
 - Allow users and services to create and share 'block' and 'allow' lists of instances, peers, or keywords that they do not want to include in search. First-time users should be able to adopt already well-known filters for abusive, fraudulent, or spam content. This is critical to prevent what can be called the "Welcome to Hell" problem, where first-time users see a bombardment of irrelevant or harmful content.
 - Provide the possibilities to curate data and expand one's network while staying local.
-- If you are using a service for your search algorithm, transparently show the name of the service along with a way to contact those people (e.g., a git repository or website). 
+- If you are using a service for your search algorithm, transparently show the name of the service along with a way to contact those people (e.g., a git repository or website).
 
 ## Potential Problems with Discovery Pub
 

--- a/patterns/discovery-pub.md
+++ b/patterns/discovery-pub.md
@@ -1,13 +1,9 @@
 ---
 title: Discovery Pub
+category:  sync-status
 tags:
   - pattern
   - protocol
-  - archiving
-  - discovery
-  - curation
-related:
-  - content-curators
 description: "Define scope and filters for decentralized search, and provide users better control over which algorithms and filters to use."
 layout: pattern
 ---
@@ -27,7 +23,7 @@ In a peer-to-peer application, you can only search for what you have downloaded,
 
 ## The Design Solution
 
-Users need to obtain a basic understanding of the differences between search that is mediated by federation and search enabled by a central discovery pub. 
+Users need to obtain a basic understanding of the differences between search that is mediated by federation and search enabled by a central service. Pair with the [Content Curators](content-curators.md) pattern. 
 
 Allow users to opt-in to search and discovery of content. For search, add indicators for scope (e.g., local vs global). For discovery, add indicators for filtering and curation. Allow users to opt-out of having their content searched through (e.g. locally vs globally).
 

--- a/patterns/disposable-identity.md
+++ b/patterns/disposable-identity.md
@@ -3,9 +3,9 @@ title: Disposable Identity
 category: agency-identity
 tags:
   - pattern
-  - protocol 
+  - protocol
 layout: pattern
-description: 
+description:
 ---
 
 ## Why Choose Disposable Identity?

--- a/patterns/disposable-identity.md
+++ b/patterns/disposable-identity.md
@@ -1,10 +1,11 @@
 ---
 title: Disposable Identity
+category: agency-identity
 tags:
   - pattern
-  - app
-  - identity
+  - protocol 
 layout: pattern
+description: 
 ---
 
 ## Why Choose Disposable Identity?

--- a/patterns/host-roulette.md
+++ b/patterns/host-roulette.md
@@ -1,9 +1,10 @@
 ---
 title: Host Roulette
+category: identity-agency
+description: "Encourage an equal distribution of users per server."
 tags:
   - pattern
-  - app
-  - identity
+  - ui 
 layout: pattern
 ---
 

--- a/patterns/host-roulette.md
+++ b/patterns/host-roulette.md
@@ -4,7 +4,7 @@ category: identity-agency
 description: "Encourage an equal distribution of users per server."
 tags:
   - pattern
-  - ui 
+  - ui
 layout: pattern
 ---
 

--- a/patterns/network-health-indicator.md
+++ b/patterns/network-health-indicator.md
@@ -1,11 +1,11 @@
 ---
 title: Network Health Indicator
+category: sync-status
+description: "Build trust through data visualizations."
 tags:
   - pattern
   - protocol
-  - activity
-  - presence
-  - sync
+  - ui
 layout: pattern
 ---
 

--- a/patterns/paper-keys.md
+++ b/patterns/paper-keys.md
@@ -1,10 +1,10 @@
 ---
 title: Paper Keys
+category: sharing-permissions
+description: "Accessible verification, backup, and sharing"
 tags:
   - pattern
-  - app
-  - recovery
-  - sharing
+  - ui
 layout: pattern
 ---
 

--- a/patterns/persistent-identity.md
+++ b/patterns/persistent-identity.md
@@ -1,9 +1,10 @@
 ---
 title: Persistent Identity
+category: identity-agency
 tags:
   - pattern
   - protocol
-  - identity
+description: "Securely move between providers and aliases."
 layout: pattern
 ---
 

--- a/patterns/persistent-identity.md
+++ b/patterns/persistent-identity.md
@@ -46,7 +46,7 @@ Matrix (p2p beta)
 ## Best Practice: How to Implement Persistent Identity
 
 - Users need to have strict control over when and where their id is shared.
-  Never automatically share this id on a public service 
+  Never automatically share this id on a public service
   unless users explicitly opt-in to publicly sharing this id, as it could be used
   nefariously by 3rd parties to contact a user without their consent.
 - Make sure that the same id is not reused across names that are intended

--- a/patterns/physical-beacon.md
+++ b/patterns/physical-beacon.md
@@ -1,10 +1,10 @@
 ---
 title: Physical Beacon
+category: sync-status
+description: "Control the physical location of data."
 tags:
   - pattern
-  - sync
-  - location
-  - archiving
+  - ui
 layout: pattern
 ---
 
@@ -17,14 +17,14 @@ relatively easy for the vast majority of cases. However, the choice of provider
 of data, based on where the user lives.
 
 For example, in Fall 2019, a change in export law required that US companies
-block users connecting from [Syria, Iran, Venezuela, Crimea and
-Cuba](https://techcrunch.com/2019/07/29/github-ban-sanctioned-countries).
-Without warning, US companies effectively cut off account access. Companies
-also give data to authorities – for example, [Yahoo! collaborated with
+block users connecting from [certain countries](https://techcrunch.com/2019/07/29/github-ban-sanctioned-countries).
+Without warning, some US companies effectively cut off account access for
+people connecting from these regions. Companies also give data to authorities
+– for example, [Yahoo! collaborated with
 China](https://www.theguardian.com/world/2013/sep/08/chinese-activist-yahoo-email-freed)
-to incriminate political dissidents in 2005. These acts set
-a dangerous precedent, where knowledge can disappear, becoming inaccessible
-permanently, or be shared with third parties without warning. This is a power
+to incriminate political dissidents in 2005. These acts set a dangerous
+precedent, where knowledge can disappear, becoming inaccessible permanently, or
+be shared with third parties without warning. This is a power
 dynamic that creates information security vulnerabilities and is especially
 dangerous for vulnerable populations with sensitive information.
 

--- a/patterns/prioritize-backup.md
+++ b/patterns/prioritize-backup.md
@@ -2,10 +2,8 @@
 title: Prioritize Backup
 tags:
   - pattern
-  - app
-  - sync
-related:
-  - tombstones
+  - ui
+category: moderation-curation 
 description: "Prioritizing backup is crucial for competing with centralized services that provide long-term storage."
 layout: pattern
 ---

--- a/patterns/prioritize-backup.md
+++ b/patterns/prioritize-backup.md
@@ -3,7 +3,7 @@ title: Prioritize Backup
 tags:
   - pattern
   - ui
-category: moderation-curation 
+category: moderation-curation
 description: "Prioritizing backup is crucial for competing with centralized services that provide long-term storage."
 layout: pattern
 ---

--- a/patterns/social-radius-slider.md
+++ b/patterns/social-radius-slider.md
@@ -1,10 +1,10 @@
 ---
 title: Social Radius Slider
+category: moderation-curation
+description: "Control information overload in large networks."
 tags:
   - pattern
-  - app
-  - social networks
-  - curation
+  - ui
 layout: pattern
 ---
 

--- a/patterns/standards-marker.md
+++ b/patterns/standards-marker.md
@@ -1,10 +1,10 @@
 ---
 title: Standards Marker
+category: sharing-permissions
+description: "Quickly find and open files that are related to your application."
 tags:
   - pattern
-  - app
-  - sharing
-  - files
+  - ui
 layout: pattern
 ---
 

--- a/patterns/tombstones.md
+++ b/patterns/tombstones.md
@@ -1,12 +1,10 @@
 ---
 title: Tombstones
+category: moderation-curation
+description: "Protect privacy & safety through networked deletion"
 tags:
   - pattern
-  - recency
-  - infrastructure
-  - curation
-  - moderation
-  - deletion
+  - protocol
 layout: pattern
 ---
 

--- a/patterns/trackers.md
+++ b/patterns/trackers.md
@@ -53,6 +53,6 @@ Trackers are a simple technique to solve "first introduction" problems in peer-t
 
 ## The Take Away
 
-Trackers are a common component of many peer-to-peer networks, and facilitate peer introduction. 
+Trackers are a common component of many peer-to-peer networks, and facilitate peer introduction.
 
 ## **References & Where to Learn More**

--- a/patterns/trackers.md
+++ b/patterns/trackers.md
@@ -4,8 +4,6 @@ category: sync-status
 tags:
   - pattern
   - protocol
-  - p2p
-  - infrastructure
 description: "Trackers can facilitate introduction in peer-to-peer networks."
 layout: pattern
 ---

--- a/patterns/village-or-city.md
+++ b/patterns/village-or-city.md
@@ -3,12 +3,7 @@ title: Village or City
 category: moderation-curation
 tags:
   - pattern
-  - curation
-  - social
-related:
-  - cautious-optimism
-  - social-radius-slider
-  - content-curators
+  - ui
 description: "Set clear expectations around the kinds of social interactions you want to see."
 layout: pattern
 ---
@@ -25,7 +20,12 @@ close connections with everyone you talk to. Think of a texting app, or an
 invite-only chat room. If it's more like a city (think Twitter), your users will have more
 interactions with strangers.
 
-Some users will want to be in a village in certain contexts; but some communities may want to feel more like cities. Making sure your assumptions about village or city is built into your platform will help users understand the kinds of interactions that are possible and appropriate.
+Some users will want to be in a village in certain contexts; but some
+communities may want to feel more like cities. Making sure your assumptions
+about village or city is built into your platform will help users understand
+the kinds of interactions that are possible and appropriate. Consider patterns
+like [cautious optimisim](cautious-optimism.md) to allow users to opt-in to
+discovering new users safely.
 
 If you envision a city-like platform, make posts public and anonymous by default - people are used to random and rude behavior in cities. But if you are building a village-like platform, people will expect posts to be shared within a smaller and safer group.
 

--- a/patterns/visual-hash.md
+++ b/patterns/visual-hash.md
@@ -51,4 +51,3 @@ visible in a typical user's social network (e.g., 1000 items).
 Visual hash is a good default image picker.
 
 ## References & Where to Learn More
-

--- a/patterns/visual-hash.md
+++ b/patterns/visual-hash.md
@@ -1,3 +1,13 @@
+---
+title: Visual Hash
+category: sharing-permissions
+tags:
+  - pattern
+  - ui
+description: "Quickly differentiate between two users or pieces of content."
+layout: pattern
+---
+
 ## The Design Problem
 
 Differentiating between users on a social network scales in difficulty with the
@@ -42,6 +52,3 @@ Visual hash is a good default image picker.
 
 ## References & Where to Learn More
 
-## Tags
-
-Social

--- a/patterns/whisper-links.md
+++ b/patterns/whisper-links.md
@@ -1,9 +1,11 @@
 ---
 title: Whisper Links
+category: sharing-permissions
 tags:
   - pattern
-  - app
-  - sharing
+  - ui
+  - protocol
+description: "Share resources quickly between two trusted users."
 layout: pattern
 ---
 


### PR DESCRIPTION
This fixes the metadata tags generally for each pattern. Each now has:

* `category`
* `description`
*  valid `tags` are only either `ui` or `protocol` 
* `related` tags moved to pattern body to be extracted programmatically