### PR TITLE
Category descriptions

### DIFF
--- a/topics/curation.md
+++ b/topics/curation.md
@@ -1,9 +1,0 @@
----
-layout: topic
-title: Moderation & Curation
-tags:
-  - topic
----
-
-This is a description of the identity topic. It adds context and makes this
-page more descriptive than a mere index.

--- a/topics/identity-agency.md
+++ b/topics/identity-agency.md
@@ -1,0 +1,8 @@
+---
+layout: topic
+title: Identity & Agency 
+tags:
+  - topic
+---
+
+In a centralized application, the concept of "who am I" is coordinated by a single authoritative database. In decentralized applications, user "accounts" may be non-existent or verified in a variety of ways. These patterns offer help bring clarity to users for how to best manage their own online identity as well as that of other people.

--- a/topics/identity-agency.md
+++ b/topics/identity-agency.md
@@ -1,6 +1,6 @@
 ---
 layout: topic
-title: Identity & Agency 
+title: Identity & Agency
 tags:
   - topic
 ---

--- a/topics/identity.md
+++ b/topics/identity.md
@@ -1,9 +1,0 @@
----
-layout: topic
-title: Agency & Identity
-tags:
-  - topic
----
-
-This is a description of the identity topic. It adds context and makes this
-page more descriptive than a mere index.

--- a/topics/moderation-curation.md
+++ b/topics/moderation-curation.md
@@ -1,0 +1,8 @@
+---
+layout: topic
+title: Moderation & Curation
+tags:
+  - topic
+---
+
+Information overload, spam, and abuse can be a serous problem if a decentralized application allows strangers to interact with each other. These patterns deal primarily with applications where content and users are publicly discoverable. By integrating these patterns, applications will be more useful to a wider set of communities, and will help keep vulnerable people safer from online abuse.

--- a/topics/sharing-permissions.md
+++ b/topics/sharing-permissions.md
@@ -1,0 +1,10 @@
+---
+layout: topic
+title: Sharing & Permissions
+tags:
+  - topic
+---
+
+Typically, decentralized applications share everything publicly by default. However, this assumption limits use cases to a narrow set of possibilities and limits user trust in the application, reducing adoption. These patterns help build trust with the application by providing methods for users to decide who sees what and when. 
+
+With sharing and permissions, people feel more comfortable to communicate more authentically with each other. In physical space, we negotiate and change our behavior with varying levels of privacy depending on where we are -- from the bedroom, to the cafe, to the public park. Virtual spaces should mimic these through clear choices about who will see what and when.

--- a/topics/sharing-permissions.md
+++ b/topics/sharing-permissions.md
@@ -5,6 +5,6 @@ tags:
   - topic
 ---
 
-Typically, decentralized applications share everything publicly by default. However, this assumption limits use cases to a narrow set of possibilities and limits user trust in the application, reducing adoption. These patterns help build trust with the application by providing methods for users to decide who sees what and when. 
+Typically, decentralized applications share everything publicly by default. However, this assumption limits use cases to a narrow set of possibilities and limits user trust in the application, reducing adoption. These patterns help build trust with the application by providing methods for users to decide who sees what and when.
 
 With sharing and permissions, people feel more comfortable to communicate more authentically with each other. In physical space, we negotiate and change our behavior with varying levels of privacy depending on where we are -- from the bedroom, to the cafe, to the public park. Virtual spaces should mimic these through clear choices about who will see what and when.

--- a/topics/sharing.md
+++ b/topics/sharing.md
@@ -1,9 +1,0 @@
----
-layout: topic
-title: Sharing & Permissions
-tags:
-  - topic
----
-
-This is a description of the identity topic. It adds context and makes this
-page more descriptive than a mere index.

--- a/topics/sync-status.md
+++ b/topics/sync-status.md
@@ -1,0 +1,8 @@
+---
+layout: topic
+title: Sync & Status
+tags:
+  - topic
+---
+
+Decentralized applications aren't always connected to a single server that is the source of truth for all information. These patterns help bring clarity about  where data is available, how it is synced across devices, and the status it's discoverability online. 

--- a/topics/sync-status.md
+++ b/topics/sync-status.md
@@ -5,4 +5,4 @@ tags:
   - topic
 ---
 
-Decentralized applications aren't always connected to a single server that is the source of truth for all information. These patterns help bring clarity about  where data is available, how it is synced across devices, and the status it's discoverability online. 
+Decentralized applications aren't always connected to a single server that is the source of truth for all information. These patterns help bring clarity about where data is available, how it is synced across devices, and the status it's discoverability online.

--- a/topics/sync.md
+++ b/topics/sync.md
@@ -1,9 +1,0 @@
----
-layout: topic
-title: Sync & Status
-tags:
-  - topic
----
-
-This is a description of the identity topic. It adds context and makes this
-page more descriptive than a mere index.


### PR DESCRIPTION
Adds descriptions to the 'topics'/'categories' and ensures the names are the same as what is expected in the pattern metadata.

fixes #26 